### PR TITLE
Be optimistic in assuming that the request body is JSON format even if

### DIFF
--- a/flask_ripozo/dispatcher.py
+++ b/flask_ripozo/dispatcher.py
@@ -68,8 +68,11 @@ def get_request_query_body_args(request_obj):
     :rtype: (dict, dict, dict)
     """
     query_args = dict(request_obj.args)
-    body = request_obj.get_json() or request_obj.form or {}
-    body = dict(body)
+    body = dict(
+        request_obj.get_json(force=True, silent=True) or
+        request_obj.form or
+        {}
+    )
 
     # Make a copy of the headers
     headers = _CaseInsentiveDict()


### PR DESCRIPTION
the content type isn't canonical. JSON API uses a content-type of
application/vnd.api+json, which Flask's request.get_json() ignores.
